### PR TITLE
Minor fix for my system

### DIFF
--- a/git-svn-migrate.sh
+++ b/git-svn-migrate.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Copyright 2010 John Albin Wilkins.
 # Available under the GPL v2 license. See LICENSE.txt.
@@ -111,8 +111,8 @@ until [[ -z "$1" ]]; do
     ignore-file )     ignore_file=$value;;
     no-minimize-url ) gitsvn_params="$gitsvn_params --no-minimize-url";;
 
-    h )               echo $help | less >&2; exit;;
-    help )            echo $help | less >&2; exit;;
+    h )               echo -e $help | less >&2; exit;;
+    help )            echo -e $help | less >&2; exit;;
 
     * )               echo "Unknown option: $option\n$usage" >&2; exit 1;;
   esac


### PR DESCRIPTION
Hi there, I added a minor fix which makes this work on my Ubuntu 10.10. system.
Initially the script failed to run:

./git-svn-migrate.sh 
./git-svn-migrate.sh: 122: [[: not found

I altered the script to use bash as interpreter, which handles the double-square-bracket.
I also altered the echo commands to use the -e switch so that the \n and \t characters were interpreted properly as escapes.

Obviously these things are system-dependent, so I'm not sure if you want to pull these changes.

Cheers,
- Luke
